### PR TITLE
exclude rust tests from parent workspaces

### DIFF
--- a/watest/Cargo.toml
+++ b/watest/Cargo.toml
@@ -24,3 +24,5 @@ url = "2.5.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 # wasmer-api = "0.0.23"
 wasmer-api = { git = "https://github.com/wasmerio/wasmer", branch="backend-api-download-url" }
+
+[workspace]


### PR DESCRIPTION
this was a problem when running integration tests from edge repo