### PR TITLE
2025 02/project cleaning

### DIFF
--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -1,0 +1,62 @@
+name: Code QA
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tet:
+    name: Run tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - uses: wasmerio/setup-wasmer@v2
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Test
+        env:
+          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
+          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
+        run: ./run.sh
+
+  fmt:
+    name: File format check
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Format & fail on changes
+        run: |
+          deno fmt --check
+
+  lint:
+    name: Lint the project
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run deno lint
+        run: |
+          deno lint

--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -1,11 +1,5 @@
-name: "Run tests with new tests pushed on main branch"
-'on':
-  pull_request:
-    branches:
-      - 'main'
-  push:
-    branches:
-      - 'main'
+name: "Run tests with new tests pushed on main branch. Intended to be run via workflow dispatch to validate dev environment."
+"on":
   workflow_dispatch:
 
 concurrency:
@@ -13,7 +7,7 @@ concurrency:
 
 jobs:
   default:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,4 +29,6 @@ jobs:
       - name: notify failure in slack
         if: failure()
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"Integration tests failed ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' https://hooks.slack.com/services/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
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{"text":"Integration tests failed ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
+          https://hooks.slack.com/services/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

--- a/.github/workflows/run-against-prod.yaml
+++ b/.github/workflows/run-against-prod.yaml
@@ -1,5 +1,5 @@
 name: "run-against-prod"
-'on':
+"on":
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -7,50 +7,44 @@ CLI, the backend and Edge.
 
 The tests are written in Typescript, and use the `deno` test runner.
 
-Follow the [Deno installation docs](https://docs.deno.com/runtime/fundamentals/installation/)
+Follow the
+[Deno installation docs](https://docs.deno.com/runtime/fundamentals/installation/)
 to install deno on your system.
 
-* Run all tests:
-  `deno test --allow-all .`
-* Run specific test(s), filtered by name:
+- Run all tests: `deno test --allow-all .`
+- Run specific test(s), filtered by name:
   `deno test --allow-all --filter <TEST-NAME> .`
 
-Use the `--parallel` flag to run multiple tests in parallel.
-By default, this will run tests with a concurrency of local CPU cores.
-You can use the `DENO_JOBS` environment variable to control the number of
-parallel tests..
+Use the `--parallel` flag to run multiple tests in parallel. By default, this
+will run tests with a concurrency of local CPU cores. You can use the
+`DENO_JOBS` environment variable to control the number of parallel tests..
 
 For example: `DENO_JOBS=8 deno test --allow-all --parallel .`
 
 ### Test target environment
 
-Tests are executed against a given test environment, and will create apps in
-a specified namespace.
+Tests are executed against a given test environment, and will create apps in a
+specified namespace.
 
 By default the Wasmer dev backend is used.
 
 The test target can be customized with environment variables.
 
 Defaults:
-* WASMER_NAMESPACE: 'wasmer-integration-tests'
-  The backend namespace to use for the tests.
-  Packages and apps will be created in this namespace.
-* WASMER_REGISTRY: 'https://registry.wasmer.wtf/graphql'
-  URL of the backend.
-* WASMER_TOKEN: <null>
-  The token for the target backend is retrieved from your wasmer config.
-  (~/.wasmer/wasmer.toml) if not specified.
-* WASMER_PATH: <null>
-  Path to the wasmer CLI executable.
-  By default the tests will just use the locally installed version.
-* WASMOPTICON_DIR: <null>
-  Path to a local clone of of the wasix-org/wasmopticon repository.
-  If not specified, tests will either use a local directory if it exists, or
-  clone the repository on demand.
-* EDGE_SERVER: <null>
-  Instead Edge with regular DNS resolution, test a specific Edge server.
-  NOTE: currently not fully working due to deno not fully implementing the 
-  required Node.js APIs.
+
+- WASMER_NAMESPACE: 'wasmer-integration-tests' The backend namespace to use for
+  the tests. Packages and apps will be created in this namespace.
+- WASMER_REGISTRY: 'https://registry.wasmer.wtf/graphql' URL of the backend.
+- WASMER_TOKEN: <null> The token for the target backend is retrieved from your
+  wasmer config. (~/.wasmer/wasmer.toml) if not specified.
+- WASMER_PATH: <null> Path to the wasmer CLI executable. By default the tests
+  will just use the locally installed version.
+- WASMOPTICON_DIR: <null> Path to a local clone of of the wasix-org/wasmopticon
+  repository. If not specified, tests will either use a local directory if it
+  exists, or clone the repository on demand.
+- EDGE_SERVER: <null> Instead Edge with regular DNS resolution, test a specific
+  Edge server. NOTE: currently not fully working due to deno not fully
+  implementing the required Node.js APIs.
 
 ## Writing tests
 
@@ -59,14 +53,13 @@ the app is running correctly on Edge.
 
 Helper code is available to make this flow more convenient.
 
-In particular, the `TestEnv` helper provides wrappers for executing CLI commands,
-creating and deploying apps,sending queries to the backend and sending HTTP
-requests to Edge.
+In particular, the `TestEnv` helper provides wrappers for executing CLI
+commands, creating and deploying apps,sending queries to the backend and sending
+HTTP requests to Edge.
 
-NOTE: **You must use the TestEnv helpers to run CLI commands and to send requests
-to Edge to ensure test environment settings are respected.**
+NOTE: **You must use the TestEnv helpers to run CLI commands and to send
+requests to Edge to ensure test environment settings are respected.**
 
- 
 The following code shows an example test with commentary:
 
 ```

--- a/bin/purge-old-apps.ts
+++ b/bin/purge-old-apps.ts
@@ -33,7 +33,8 @@ async function purgeOldApps(
           await env.backend.deleteApp(app.id);
           deletedCounter++;
         } catch (err) {
-          if (!(err as any).toString().includes("is already deleted")) {
+          const typedErr = err instanceof Error ? err : false;
+          if (!(typedErr && typedErr.message.includes("is already deleted"))) {
             throw err;
           }
         }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@std/toml": "jsr:@std/toml@^1.0.2",
+    "zod": "npm:zod@^3.24.1"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,67 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.11",
+    "jsr:@std/collections@^1.0.9": "1.0.10",
+    "jsr:@std/fs@*": "1.0.11",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/toml@*": "1.0.2",
+    "jsr:@std/toml@^1.0.2": "1.0.2",
+    "jsr:@std/yaml@*": "1.0.5",
+    "npm:@types/node@*": "22.5.4",
+    "npm:zod@^3.24.1": "3.24.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.11": {
+      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/collections@1.0.10": {
+      "integrity": "903af106a3d92970d74e20f7ebff77d9658af9bef4403f1dc42a7801c0575899"
+    },
+    "@std/fs@1.0.11": {
+      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    },
+    "@std/toml@1.0.2": {
+      "integrity": "5892ba489c5b512265a384238a8fe8dddbbb9498b4b210ef1b9f0336a423a39b",
+      "dependencies": [
+        "jsr:@std/collections"
+      ]
+    },
+    "@std/yaml@1.0.5": {
+      "integrity": "71ba3d334305ee2149391931508b2c293a8490f94a337eef3a09cade1a2a2742"
+    }
+  },
+  "npm": {
+    "@types/node@22.5.4": {
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "undici-types@6.19.8": {
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "zod@3.24.1": {
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/toml@^1.0.2",
+      "npm:zod@^3.24.1"
+    ]
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,11 @@ import { buildDir, DirEntry, Path } from "./fs.ts";
 // Definition for an app.
 // Contains an optional package definition, directory tree and app.yaml configuration.
 export interface AppDefinition {
+  // TODO: Setup zod object for wasmerToml
+  // deno-lint-ignore no-explicit-any
   wasmerToml?: Record<string, any>;
+  // TODO: Setup zod object for appYaml
+  // deno-lint-ignore no-explicit-any
   appYaml: Record<string, any>;
   files?: DirEntry;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { ENV_VAR_WASMOPTICON_DIR } from "./env.ts";
 // Path to the wasmopticon repo.
 export async function wasmopticonDir(): Promise<string> {
   const WASMOPTICON_GIT_URL = "https://github.com/wasix-org/wasmopticon.git";
-  let dir = process.env[ENV_VAR_WASMOPTICON_DIR];
+  const dir = process.env[ENV_VAR_WASMOPTICON_DIR];
   if (dir) {
     const doesExist = await exists(dir);
     if (!doesExist) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,3 @@
 export async function sleep(milliseconds: number) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  return await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }


### PR DESCRIPTION
The removed tests each has its own linear task to be recreated:
1. [SRE-646: Integration test: App deletion](https://linear.app/wasmer/issue/SRE-646/integration-test-app-deletion)
2. [SRE-645: Integration test: Email sending](https://linear.app/wasmer/issue/SRE-645/integration-test-email-sending)

Changes:
* Setup pipelines for QA which includes:
  - Linting
  - Formatting
  - Testing (moved from 'push-to-main' workflow to here)
* Introduced [zod](https://zod.dev) to standardize and improve type validation
* Fixed purge all apps workflow (which should be broken due to missing import)
* Added deno.json (my lsp doesn't get its a deno project otherwise)