### PR TITLE
Cronjob tests + github actions cleanup

### DIFF
--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -8,24 +8,10 @@ on:
       - main
 
 jobs:
-  tet:
-    name: Run tests
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - uses: wasmerio/setup-wasmer@v2
-      - name: Install Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Test
-        env:
-          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
-          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
-        run: ./run.sh
+  tests:
+    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main
+    secrets:
+      WAPM_DEV_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
 
   fmt:
     name: File format check

--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main
+    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@sre-183-integration-tests-exec-cronjob-cli-log-validation
     secrets:
       WAPM_DEV_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
 

--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@sre-183-integration-tests-exec-cronjob-cli-log-validation
+    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main
     secrets:
       WAPM_DEV_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
 

--- a/.github/workflows/integration-test-workflow.yaml
+++ b/.github/workflows/integration-test-workflow.yaml
@@ -1,0 +1,53 @@
+name: Integration Test Workflow
+
+on:
+  workflow_call:
+    secrets:
+      WAPM_DEV_TOKEN:
+        required: true
+
+jobs:
+  run-unspecified-tests:
+    name: Run root tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: wasmerio/setup-wasmer@v2
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Test
+        env:
+          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
+          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
+        run: ./run.sh
+
+  run-logvalidation-tests:
+    name: Run log tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: wasmerio/setup-wasmer@v2
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Test
+        env:
+          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
+          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
+        run: |
+          # Run test which only passes if logging works
+          deno test --filter "Log test: Check fetch is logged on simple logging app" --allow-all --quiet
+          # ... and then the tests which depend on logging for validation. Doesn't make any
+          # sense to run these if we know that logging doesn't work: just a waste of resources
+          deno test --allow-all src/tests/log-validation --quiet .

--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -6,26 +6,11 @@ concurrency:
   group: push-to-main
 
 jobs:
-  default:
-    runs-on: ubuntu-24.04
+  tests:
+    uses: ./.github/workflows/test-jobs.yaml
+    secrets:
+      WAPM_DEV_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - run: |
-          find .
-      - uses: wasmerio/setup-wasmer@v2
-      - uses: denoland/setup-deno@v1
-      - name: whoami
-        env:
-          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
-          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
-        run: wasmer whoami
-      - name: test
-        env:
-          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
-          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
-        run: deno test --allow-all --parallel
       - name: notify failure in slack
         if: failure()
         run: |

--- a/.github/workflows/run-against-prod.yaml
+++ b/.github/workflows/run-against-prod.yaml
@@ -1,3 +1,5 @@
+# This file has been deprecated!
+# Please use the integration-test-workflow.yaml instead
 name: "run-against-prod"
 "on":
   workflow_dispatch:

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-DENO_JOBS=8 deno test --allow-all --quiet --parallel .
+DENO_JOBS=8 deno test --allow-all --quiet --parallel test.ts

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -33,17 +33,11 @@ export function buildStaticSiteApp(): AppDefinition & {
       },
       fs: {
         "/public": "public",
-        // "/settings": "settings",
       },
       command: [{
         name: "script",
         module: "wasmer/static-web-server:webserver",
         runner: "https://webc.org/runner/wasi",
-        // annotations: {
-        //   wasi: {
-        //     'main-args': ["-w", "/settings/config.toml"],
-        //   }
-        // }
       }],
     },
     appYaml: {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,101 @@
+import { fail } from "node:assert";
+import { TestEnv } from "./env.ts";
+import { resolve } from "node:path";
+
+export function countSubstrings(str: string, subStr: string): number {
+  if (subStr === "") {
+    return 0;
+  }
+  let count = 0;
+  let pos = str.indexOf(subStr);
+  while (pos !== -1) {
+    count++;
+    pos = str.indexOf(subStr, pos + 1);
+  }
+  return count;
+}
+
+export class LogSniff {
+  private env: TestEnv;
+
+  public constructor(env: TestEnv) {
+    this.env = env;
+  }
+
+  public async assertLogsWithin(
+    appName: string,
+    want: string,
+    withinMs: number,
+    requiredHits: number = 1,
+    minimumTimeoutMs: number = 0,
+  ): Promise<void> {
+    const t0 = new Date().getTime();
+    let resolveTest: (value: void | PromiseLike<void>) => void;
+    const p = new Promise<void>((resolveMe) => {
+      if (resolve != null) {
+        resolveTest = resolveMe;
+      }
+    });
+    let latestError: Error;
+    const intervalID = setInterval(
+      async () => {
+        const now = new Date().getTime();
+        const overMinimumTimeframe = now > (t0 + minimumTimeoutMs);
+        const overTestTimeout = now > (t0 + withinMs);
+        let amSubstrings = -1;
+        let allLogs = "";
+        try {
+          allLogs = await getAllLogs(this.env, appName);
+          amSubstrings = countSubstrings(allLogs, want);
+          if (
+            amSubstrings === requiredHits &&
+            overMinimumTimeframe
+          ) {
+            clearInterval(intervalID);
+            resolveTest();
+            return;
+          }
+        } catch (e) {
+          if (e instanceof Error) {
+            latestError = e;
+          }
+        }
+
+        if (overTestTimeout) {
+          const errorStr = latestError ? ` Latest error: ${latestError}.` : "";
+          const amSubstringsStr = amSubstrings > 0
+            ? `Latest amSubstrings: ${amSubstrings}.`
+            : "";
+          // Wrap the allLogs print with newlines to make it easier to read
+          allLogs = allLogs !== "" ? `\n${allLogs}` : "";
+
+          fail(
+            `failed to find any substring: '${want}' from the apps logs within: ${withinMs}ms.${amSubstringsStr}${errorStr} Latest logs:${allLogs}`,
+          );
+        }
+      },
+      3000,
+    );
+    await p;
+  }
+}
+
+/***
+ * getAllLogs for an environment which has a deployed app within it.
+ */
+export async function getAllLogs(
+  env: TestEnv,
+  appName: string,
+): Promise<string> {
+  const cmdResp = await env.runWasmerCommand(
+    {
+      args: ["app", "logs", `wasmer-integration-tests/${appName}`],
+    },
+  );
+  if (cmdResp.code != 0) {
+    throw new Error(
+      `failed to get logs for: '${appName}. Recieved status code: ${cmdResp.code}, out: ${cmdResp.stdout}, err: ${cmdResp.stderr}`,
+    );
+  }
+  return cmdResp.stdout;
+}

--- a/src/tests/log-validation/job.test.ts
+++ b/src/tests/log-validation/job.test.ts
@@ -1,0 +1,162 @@
+import { AppInfo } from "../../backend.ts";
+import { TestEnv } from "../../env.ts";
+import { LogSniff } from "../../log.ts";
+import fs from "node:fs";
+import { randomAppName } from "../../app/index.ts";
+import { buildPhpApp } from "../../app/php.ts";
+
+/**
+ * Tests in this file are separate to allow them to run in parallell
+ */
+const SECOND = 1000;
+
+type Action = {
+  fetch?: {
+    path: string;
+    timeout: string;
+  };
+  execute?: {
+    command: string;
+    cli_args: string[];
+  } | undefined;
+};
+type Job = {
+  name: string;
+  trigger: string;
+  action: Action;
+};
+async function performTest(
+  t: Deno.TestContext,
+  jobs: Job[],
+  logValidationStr: string,
+  timeoutSec: number,
+  expectLogOccurance: number = 1,
+  minimumTimeoutSec: number = 0,
+) {
+  const env = TestEnv.fromEnv();
+  const appName = randomAppName();
+  let deployedApp: AppInfo;
+
+  const filePath = "./src/tests/path-logger.php";
+  const phpPathLogger = await fs.promises.readFile(filePath, "utf-8");
+
+  await t.step("Deploy app", async () => {
+    const spec = buildPhpApp(phpPathLogger, { name: appName });
+    spec.appYaml.name = appName;
+    spec.appYaml.jobs = jobs;
+    // NOTE: This is added to ensure that the job only runs once. If a region
+    // isn't specified, it'll run once per region, skewing the logs
+    spec.appYaml.locality = {
+      regions: ["be-mons"],
+    };
+    console.debug(JSON.stringify(spec, null, " "));
+    deployedApp = await env.deployApp(spec);
+  });
+
+  await t.step("check logs", async () => {
+    const logSniff = new LogSniff(env);
+    await logSniff.assertLogsWithin(
+      appName,
+      logValidationStr,
+      timeoutSec * SECOND,
+      expectLogOccurance,
+      minimumTimeoutSec,
+    );
+  });
+
+  await t.step("delete app", async () => {
+    await env.deleteApp(deployedApp);
+  });
+}
+
+Deno.test("Logvalidation - Http job: post-deployment", {}, async (t) => {
+  await performTest(
+    t,
+    [
+      {
+        name: randomAppName(),
+        trigger: "post-deployment",
+        action: {
+          fetch: {
+            path: "/this-is-fetch-from-post-deploy-job",
+            timeout: "30s",
+          },
+        },
+      },
+    ],
+    "this-is-fetch-from-post-deploy-job",
+    15,
+  );
+});
+
+Deno.test("Logvalidation - Exec job: post-deployment", {}, async (t) => {
+  await performTest(
+    t,
+    [
+      {
+        name: randomAppName(),
+        trigger: "post-deployment",
+        action: {
+          execute: {
+            cli_args: [
+              "-r",
+              "fwrite(fopen('php://stderr', 'w'), 'cronjob-exec-post-deployment');",
+            ],
+            command: "php",
+          },
+        },
+      },
+    ],
+    "cronjob-exec-post-deployment",
+    15,
+  );
+});
+
+async function cronjobTest(
+  t: Deno.TestContext,
+  name: string,
+  action: Action,
+  logValidationStr: string,
+) {
+  await performTest(
+    t,
+    [
+      {
+        name: name,
+        trigger: "*/1 * * * *",
+        action: action,
+      },
+    ],
+    logValidationStr,
+    // Timeout is quite long to take account for the initial scheduling of 1 minute,
+    // and then wait for the second iteration, occuring after another minute
+    130,
+    2,
+    // Set minimum timeout to 125 seconds, here it should have run twice
+    // This is needed since we have an edge case where the fetch runs multiple times and
+    // makes the test complete prematurely (and falsely: we don't know if it'll repeat,
+    // and also, it shouldn't run more than once per run)
+    125,
+  );
+}
+
+Deno.test("Logvalidation - Http cronjob: every minute", {}, async (t) => {
+  await cronjobTest(t, randomAppName(), {
+    fetch: {
+      path: "/this-is-fetch-from-cron-job",
+      timeout: "30s",
+    },
+  }, "this-is-fetch-from-cron-job");
+});
+
+Deno.test("Logvalidation - Exec cronjob: every minute", {}, async (t) => {
+  await cronjobTest(t, randomAppName(), {
+    execute: {
+      cli_args: [
+        "-r",
+        "fwrite(fopen('php://stderr', 'w'), 'cronjob-exec-every-1-min');",
+      ],
+      command: "php",
+    },
+  }, "cronjob-exec-every-1-min");
+});

--- a/src/tests/log.test.ts
+++ b/src/tests/log.test.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from "jsr:@std/assert/equals";
+import { AppInfo } from "../backend.ts";
+import { TestEnv } from "../env.ts";
+import { countSubstrings, LogSniff } from "../log.ts";
+import fs from "node:fs";
+import { randomAppName } from "../app/index.ts";
+import { buildPhpApp } from "../app/php.ts";
+
+const SECOND = 1000;
+
+Deno.test(
+  "Log test: Check fetch is logged on simple logging app",
+  {},
+  async (t) => {
+    const filePath = "./src/tests/path-logger.php";
+    const phpPathLogger = await fs.promises.readFile(filePath, "utf-8");
+    const env = TestEnv.fromEnv();
+    const appName = randomAppName();
+    let deployedApp: AppInfo;
+
+    await t.step("Deploy app", async () => {
+      const spec = buildPhpApp(phpPathLogger, { name: appName });
+      spec.appYaml.name = appName;
+      console.log(JSON.stringify(spec, null, " "));
+      deployedApp = await env.deployApp(spec);
+      await env.fetchApp(deployedApp, "/this-is-a-unique-path");
+    });
+
+    await t.step("check logs", async () => {
+      const logSniff = new LogSniff(env);
+      await logSniff.assertLogsWithin(
+        appName,
+        "this-is-a-unique-path",
+        15 * SECOND,
+      );
+    });
+
+    await t.step("delete app", async () => {
+      await env.deleteApp(deployedApp);
+    });
+  },
+);
+
+Deno.test("Unittest: countSubstrings", async (t) => {
+  await t.step("counts single occurrence", () => {
+    assertEquals(countSubstrings("hello world", "world"), 1);
+  });
+
+  await t.step("counts multiple occurrences", () => {
+    assertEquals(countSubstrings("hello hello hello", "hello"), 3);
+  });
+
+  await t.step("returns 0 for no occurrences", () => {
+    assertEquals(countSubstrings("hello world", "goodbye"), 0);
+  });
+
+  await t.step("handles empty string", () => {
+    assertEquals(countSubstrings("", "test"), 0);
+  });
+
+  await t.step("handles empty substring", () => {
+    assertEquals(countSubstrings("hello world", ""), 0);
+  });
+
+  await t.step("handles overlapping substrings", () => {
+    // Hmm.. Not great, not terrible
+    assertEquals(countSubstrings("aaaaa", "aa"), 4);
+  });
+});

--- a/src/tests/path-logger.php
+++ b/src/tests/path-logger.php
@@ -1,0 +1,7 @@
+<?php
+ // Get the requested path
+$path = $_SERVER['REQUEST_URI'];
+
+// Print the request with a timestamp
+echo date('Y-m-d H:i:s') . " - " . $path . "\n";
+fwrite(fopen('php://stderr', 'w'),  date('Y-m-d H:i:s') . " - " . $path . "\n");


### PR DESCRIPTION
This sets up tests for:
* Logging
* Exec cronjobs
* Fetch cronjob

In addition, it:
* Sets up a proper workflow which can (and should) be used for testing in adjacent repositories (no more [git clones + manual deno tests](https://github.com/wasmerio/edge/blob/main/.github/workflows/dev-release.yaml#L260))
* Cleans up minor things