### PR TITLE
Backend integration test tweaks (breaking changes)

### DIFF
--- a/.github/workflows/integration-test-workflow.yaml
+++ b/.github/workflows/integration-test-workflow.yaml
@@ -1,19 +1,23 @@
 name: Integration Test Workflow
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:
-      test_failure_webhook:
-        required: false
-        type: string
-        description: "Add optional webhook which will be called if any tests have failed"
       fetch_artifact:
         required: false
         type: string
         description: "Set to the name of the wasmer artifact you'd like to fetch and use in the integration tests."
     secrets:
-      WAPM_DEV_TOKEN:
+      token:
         required: true
+        description: "Token used to authenticate towards some wasmer backend"
+      test_failure_webhook:
+        required: false
+        description: "Add optional webhook which will be called if any tests have failed"
 
 jobs:
   run-unspecified-tests:
@@ -34,7 +38,7 @@ jobs:
       - name: Test
         env:
           WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
-          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
+          WASMER_TOKEN: ${{ secrets.token }}
         run: |
           ./run.sh
       - name: Notify failure in Slack
@@ -62,7 +66,7 @@ jobs:
       - name: Test
         env:
           WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
-          WASMER_TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
+          WASMER_TOKEN: ${{ secrets.token }}
         run: |
           # Run test which only passes if logging works
           deno test --filter "Log test: Check fetch is logged on simple logging app" --allow-all --quiet

--- a/.github/workflows/integration-test-workflow.yaml
+++ b/.github/workflows/integration-test-workflow.yaml
@@ -11,10 +11,15 @@ on:
         required: false
         type: string
         description: "Set to the name of the wasmer artifact you'd like to fetch and use in the integration tests."
+      regitry:
+        required: false
+        type: string
+        description: "Path to the graphql of the registry you'd like to test. See default."
+        default: "https://registry.wasmer.wtf/graphql"
     secrets:
       token:
         required: true
-        description: "Token used to authenticate towards some wasmer backend"
+        description: "Token used to authenticate towards the wasmer backend"
       test_failure_webhook:
         required: false
         description: "Add optional webhook which will be called if any tests have failed"
@@ -37,17 +42,17 @@ jobs:
           fetch_artifact: ${{ inputs.fetch_artifact }}
       - name: Test
         env:
-          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
+          WASMER_REGISTRY: ${{ inputs.registry }}
           WASMER_TOKEN: ${{ secrets.token }}
         run: |
           ./run.sh
       - name: Notify failure in Slack
-        if: failure() && inputs.test_failure_webhook != ''
+        if: failure() && secrets.test_failure_webhook != ''
         run: |
           curl -X POST \
             -H 'Content-type: application/json' \
             --data '{"text":"General integration tests failed ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
-            ${{ inputs.test_failure_webhook }}
+            ${{ secrets.test_failure_webhook }}
 
   run-logvalidation-tests:
     name: Run tests which use logging for validation
@@ -65,7 +70,7 @@ jobs:
           fetch_artifact: ${{ inputs.fetch_artifact }}
       - name: Test
         env:
-          WASMER_REGISTRY: https://registry.wasmer.wtf/graphql
+          WASMER_REGISTRY: ${{ inputs.registry }}
           WASMER_TOKEN: ${{ secrets.token }}
         run: |
           # Run test which only passes if logging works
@@ -74,9 +79,9 @@ jobs:
           # sense to run these if we know that logging doesn't work: just a waste of resources
           deno test --allow-all src/tests/log-validation --quiet
       - name: Notify failure in Slack
-        if: failure() && inputs.test_failure_webhook != ''
+        if: failure() && secrets.test_failure_webhook != ''
         run: |
           curl -X POST \
             -H 'Content-type: application/json' \
             --data '{"text":"Log-validation based integration tests failed ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
-            ${{ inputs.test_failure_webhook }}
+            ${{ secrets.test_failure_webhook }}


### PR DESCRIPTION
After some good findings from @ayys I recreated his ticket with the same tweaks (pretty much) so that he can focus on non-plumbing stuff.

Changes:
* Removed any mention of 'wapm' (removed from token secret, this breaks all current workflow callees)
* Added registry as a variable to allow for environment targeting down the line
* Made test_failure_webhook a secret