### PR TITLE
Lock deno version to 2.1

### DIFF
--- a/.github/actions/setup-test-env/action.yaml
+++ b/.github/actions/setup-test-env/action.yaml
@@ -5,7 +5,6 @@ inputs:
   fetch_artifact:
     description: "Set to the name of artifact you want to overwrite the default wasmer binary with"
     required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -14,9 +13,9 @@ runs:
     - name: Install Deno
       uses: denoland/setup-deno@v2
       with:
-        deno-version: v2.x
+        deno-version: v2.1
     - uses: actions/download-artifact@v4
-      if: inputs.fetch_artifact
+      if: inputs.fetch_artifact != ''
       with:
         name: ${{ inputs.fetch_artifact }}
     - name: Overwrite wasmer binary

--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main
+    uses: ./.github/workflows/integration-test-workflow.yaml
     secrets:
       token: ${{ secrets.WAPM_DEV_TOKEN }}
 


### PR DESCRIPTION
We were [recently blessed with deno 2.2](https://github.com/denoland/deno/releases/tag/v2.2.0), which might be the cause for the [unexplainably failing pipelines](https://github.com/wasmerio/backend/actions/runs/13410665339/job/37460412404)