### PR TITLE
Updated successful deploy string

### DIFF
--- a/tests/wordpress.test.ts
+++ b/tests/wordpress.test.ts
@@ -93,7 +93,7 @@ Deno.test("app-wordpress", {}, async (t) => {
   await t.step("validate autosetup", async () => {
     await logSniff.assertLogsWithin(
       appYaml.name!,
-      "Installation complete",
+      "was successfully deployed",
       30 * SECOND,
     );
   });


### PR DESCRIPTION
I think we've changed what's  printed when deployment works out. 