### PR TITLE
App blackhole-banning test

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,36 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  // Use the deno LSP
+  "lsp": {
+    "deno": {
+      "settings": {
+        "deno": {
+          "enable": true
+        }
+      }
+    }
+  },
+  "languages": {
+    "TypeScript": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server"
+    },
+    "TSX": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server"
+    }
+  }
+}

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -214,4 +214,41 @@ mutation($id:ID!) {
       throw new Error(`Failed to delete app: ${appId}`);
     }
   }
+
+  async banApp(
+    { appId, reason, blackhole }: {
+      appId: string;
+      reason: string;
+      blackhole: boolean;
+    },
+  ): Promise<string> {
+    const Input = z.object({
+      banApp: z.object({
+        app: z.object({ id: z.string() }),
+      }),
+    });
+    type Input = z.infer<typeof Input>;
+
+    const query = `
+      mutation($appId:ID!, $reason:String!,$blackholed:Boolean!) {
+        banApp(input:{appId:$appId, reason:$reason, blackholed:$blackholed}) {
+          app {
+            id
+          }
+        }
+      }
+    `;
+
+    const res = await this.gqlQuery<Input>(query, {
+      appId,
+      reason,
+      blackholed: blackhole,
+    });
+
+    const id = res.data?.banApp?.app?.id;
+    if (!id) {
+      throw new Error("banApp mutation did not return an app id");
+    }
+    return id;
+  }
 }

--- a/tests/app/app_banning.test.ts
+++ b/tests/app/app_banning.test.ts
@@ -1,0 +1,49 @@
+import { assert } from "jsr:@std/assert";
+
+import { buildStaticSiteApp, sleep, TestEnv } from "../../src/index.ts";
+
+// Test that blackholed apps do not serve DNS records anymore.
+Deno.test("app-ban-blackholed", async () => {
+  const spec = buildStaticSiteApp();
+
+  // Enable debug mode to allow for instance ID and instance purging.
+  spec.appYaml.debug = true;
+
+  const env = TestEnv.fromEnv();
+  const info = await env.deployApp(spec);
+  const domain = (new URL(info.url)).host;
+
+  const _res = await env.fetchApp(info, "/");
+  const ips = await env.resolveAppDns(info);
+  assert(ips.a.length > 0, "No IPs found for app URL");
+
+  // Now blackhole-ban the app.
+  console.log("Banning app through backend API...");
+  await env.backend.banApp({ appId: info.id, reason: "test", blackhole: true });
+
+  // Wait for the app to be blackholed.
+
+  console.log("waiting for Edge server to stop serving DNS records...");
+
+  const start = Date.now();
+
+  const timeoutSecs = 60;
+  while (true) {
+    const newIps = await env.resolveAppDns(info);
+    if (newIps.a.length == 0 && newIps.aaaa.length == 0) {
+      break;
+    }
+    console.log("dns server is still returning records for domain", {
+      domain,
+      newIps,
+    });
+
+    const elapsed = Date.now() - start;
+    if (elapsed > timeoutSecs * 1000) {
+      throw new Error(
+        `Timed out waiting for app ${domain} to be blackholed - still serving DNS records after ${timeoutSecs} seconds`,
+      );
+    }
+    await sleep(1000);
+  }
+});


### PR DESCRIPTION
Add a test for app blackhole banning, which must stop serving DNS records
for the app domain.

See EDGE-1197

- **chore: Add zed-editor config**
- **feat: Add Backend.banApp method**
- **feat: Add Env.resolveAppDns helper**
- **tests: Add app blackhole ban test**
