### PR TITLE
feat: Added nightly integration tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,16 @@
+name: Code QA
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    uses: ./.github/workflows/integration-test-workflow.yaml
+    with:
+      test_branch: ${{ github.head_ref }}
+    secrets:
+      token: ${{ secrets.WAPM_DEV_TOKEN }}


### PR DESCRIPTION
From my local testing, there weren't any non-flaky failing tests.

But, I figured I might as well add nightly tests, since we don't run the integration tests very often unless either Backend or Edge has pushed changes. 