### PR TITLE
trace(SRE-872): Modifications to trigger failure more consistently + detecty why

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -619,6 +619,7 @@ subscription PublishAppFromRepoAutobuild(
           console.info(
             `App is not at expected version ${waitForVersionId} (got ${currentId}), retrying after delay...`,
           );
+          console.log(`Response body: ${await response.text()}`)
           await sleep(1000);
           // Retry...
           continue;

--- a/tests/general/test.ts
+++ b/tests/general/test.ts
@@ -506,8 +506,9 @@ test.concurrent("app-update-multiple-times", async () => {
 
   const indexPath = path.join(info1.dir, "public/index.html");
 
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 10; i++) {
     const content = `hello-${i}`;
+    console.log(`Now I want to see: ${content}`);
     await fs.promises.writeFile(indexPath, content);
     await env.deployAppDir(info1.dir);
 


### PR DESCRIPTION
This is to enable reproduction of [BE-798: Deploy app version ID isn't properly set (keeps old ID)](https://linear.app/wasmer/issue/BE-798/deploy-app-version-id-isnt-properly-set-keeps-old-id)