### PR TITLE
fix: Unset EDGE_SSH_SERVER in ssh-shell-exec unit tests

### DIFF
--- a/tests/ssh/ssh-shell-exec.test.ts
+++ b/tests/ssh/ssh-shell-exec.test.ts
@@ -89,6 +89,19 @@ class FakeShellStream extends EventEmitter {
   }
 }
 
+// These tests target the interactive-shell marker parsing, so force
+// sshShellExec down the shell path: with EDGE_SSH_SERVER set (as in the local
+// platform CI env) it would first try conn.exec, which the fake lacks.
+const savedEdgeSshServer = process.env.EDGE_SSH_SERVER;
+beforeAll(() => {
+  delete process.env.EDGE_SSH_SERVER;
+});
+afterAll(() => {
+  if (savedEdgeSshServer !== undefined) {
+    process.env.EDGE_SSH_SERVER = savedEdgeSshServer;
+  }
+});
+
 function fakeConn(stream: FakeShellStream): Client {
   return {
     shell: (cb: (err: Error | undefined, stream: FakeShellStream) => void) => {


### PR DESCRIPTION
## Problem

The ssh suite of the backend's local-platform QA fails ([example run](https://github.com/wasmerio/backend/actions/runs/28591181194/job/84778695502?pr=2877)) with all five tests/ssh/ssh-shell-exec.test.ts cases throwing:

```
TypeError: conn.exec is not a function   at src/ssh.ts:328
```

The local-platform test environment exports `EDGE_SSH_SERVER`, which makes `sshShellExec` try the `conn.exec` fast path before the interactive-shell fallback. The suite's fake connection only implements `shell`, so the TypeError doesn't match the "Unable to exec" fallback condition and is rethrown. Locally the tests pass because `EDGE_SSH_SERVER` is unset.

## Fix

Delete `EDGE_SSH_SERVER` in `beforeAll` (restored in `afterAll`) so the suite deterministically exercises the interactive-shell marker-parsing path it was written to test.

Verified: suite passes both with and without `EDGE_SSH_SERVER` set; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)