### PR TITLE
Add SCP app volume copy integration test

### DIFF
--- a/tests/ssh/app-ssh.test.ts
+++ b/tests/ssh/app-ssh.test.ts
@@ -1,6 +1,10 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
 import SftpClient from "ssh2-sftp-client";
 
-import { TestEnv } from "../../src";
+import { createTempDir, TestEnv } from "../../src";
 import {
   AppCapabilities,
   SshCapability,
@@ -15,7 +19,82 @@ import {
   readTestSshPrivateKey,
   readTestSshPublicKey,
   sshShellExec,
+  TEST_SSH_PRIVATE_KEY_PATH,
 } from "../../src/ssh";
+
+interface CommandResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runScp(args: string[]): Promise<CommandResult> {
+  console.info(`Running scp ${args.join(" ")}`);
+  const proc = spawn("scp", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  const timeoutMs = 120_000;
+
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      proc.kill("SIGTERM");
+      reject(
+        new Error(`scp timed out after ${timeoutMs}ms: scp ${args.join(" ")}`),
+      );
+    }, timeoutMs);
+
+    proc.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    proc.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    proc.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      const result = {
+        code,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+      };
+      if (code !== 0) {
+        reject(
+          new Error(
+            `scp failed with code ${code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+async function snapshotDirectory(
+  root: string,
+): Promise<Record<string, string>> {
+  const entries: Record<string, string> = {};
+
+  async function visit(dir: string): Promise<void> {
+    const dirents = await fs.readdir(dir, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const fullPath = path.join(dir, dirent.name);
+      const relativePath = path
+        .relative(root, fullPath)
+        .split(path.sep)
+        .join("/");
+      if (dirent.isDirectory()) {
+        await visit(fullPath);
+      } else if (dirent.isFile()) {
+        entries[relativePath] = await fs.readFile(fullPath, "utf8");
+      }
+    }
+  }
+
+  await visit(root);
+  return entries;
+}
 
 const setupApp = async (env: TestEnv) => {
   const { dir, definition } = await preparePhpTestserverApp(env);
@@ -242,6 +321,80 @@ test("app-sftp", async () => {
       })(),
     ).rejects.toBeTruthy();
   } finally {
+    await env.deleteApp(sshDeployment);
+  }
+});
+
+test("app-scp", async () => {
+  const env = TestEnv.fromEnv();
+  const { sshUsername, sshDeployment } = await setupApp(env);
+
+  const target = env.edgeSshTarget();
+  const hostname = target?.host ?? new URL(sshDeployment.url).hostname;
+  const port = target?.port ?? 22;
+  const tmpDir = await createTempDir();
+  const downloadDir = await createTempDir();
+  const fixtureName = `scp-e2e-${crypto.randomUUID()}`;
+  const fixtureDir = path.join(tmpDir, fixtureName);
+  const privateKeyPath = path.join(tmpDir, "id_rsa_test");
+  const remoteDir = `/data/${fixtureName}`;
+
+  await fs.copyFile(TEST_SSH_PRIVATE_KEY_PATH, privateKeyPath);
+  await fs.chmod(privateKeyPath, 0o600);
+  await fs.mkdir(path.join(fixtureDir, "nested", "deeper"), {
+    recursive: true,
+  });
+  await fs.writeFile(
+    path.join(fixtureDir, "root.txt"),
+    `root file ${fixtureName}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(fixtureDir, "nested", "child.txt"),
+    `nested file ${fixtureName}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(fixtureDir, "nested", "deeper", "binary-ish.txt"),
+    "line one\nline two\nsymbols: !@#$%^&*()\n",
+    "utf8",
+  );
+
+  const scpBaseArgs = [
+    "-r",
+    "-P",
+    String(port),
+    "-i",
+    privateKeyPath,
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "IdentitiesOnly=yes",
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "UserKnownHostsFile=/dev/null",
+  ];
+
+  try {
+    console.log(`SCP to ${sshUsername}@${hostname}:${port}`);
+    await runScp([
+      ...scpBaseArgs,
+      fixtureDir,
+      `${sshUsername}@${hostname}:/data/`,
+    ]);
+    await runScp([
+      ...scpBaseArgs,
+      `${sshUsername}@${hostname}:${remoteDir}`,
+      downloadDir,
+    ]);
+
+    await expect(
+      snapshotDirectory(path.join(downloadDir, fixtureName)),
+    ).resolves.toEqual(await snapshotDirectory(fixtureDir));
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    await fs.rm(downloadDir, { recursive: true, force: true });
     await env.deleteApp(sshDeployment);
   }
 });


### PR DESCRIPTION
## Summary

- add an `app-scp` integration test for copying a synthetic nested directory to an app volume using the system `scp` binary
- copy the directory back from the app volume and verify the returned file tree contents match exactly
- reuse the existing SSH app setup with `/data` volume and SSH enabled

## Important rollout note

This PR is expected to fail the new SCP test until the upstream Edge fix has finished deploying. The test intentionally has no workaround for the previous SFTP/session-close stall, so both upload and download SCP commands must exit cleanly.

## Verification

- `make fmt && make lint`
- Focused SCP test was started after removing the timeout workaround, but interrupted because the upstream Edge deployment is still rolling out and the test is expected to fail until that deployment is complete.