### PR TITLE
test: cover autobuild redeploy with current app domain

### DIFF
--- a/tests/stackmachine/stackmachine-sdk.test.ts
+++ b/tests/stackmachine/stackmachine-sdk.test.ts
@@ -275,6 +275,35 @@ describe("stackmachine sdk", () => {
     await expectAppBody(env, app2, "Hello World v2!");
   });
 
+  test("redeployFromFiles accepts the app's current default domain", async () => {
+    const env = TestEnv.fromEnv();
+    const client = await env.stackmachineSdk();
+    const appName = randomAppName();
+
+    const app1 = await deployInlinePhpApp(
+      client,
+      env,
+      "<html><body><h1>Default domain v1!</h1></body></html>",
+      appName,
+    );
+    cleanupAppIds.push(app1.id);
+
+    const currentDefaultDomain = new URL(app1.url).hostname;
+    const app2 = await deployInlinePhpApp(
+      client,
+      env,
+      "<html><body><h1>Default domain v2!</h1></body></html>",
+      appName,
+      {
+        allowExistingApp: true,
+        domains: [currentDefaultDomain],
+      },
+    );
+
+    expect(app2.id).toBe(app1.id);
+    await expectAppBody(env, app2, "Default domain v2!");
+  });
+
   test("deployPerishable example", async () => {
     const env = TestEnv.fromEnv();
     const client = await env.stackmachineSdk();


### PR DESCRIPTION
## Summary

- cover redeploying an existing app while reusing its current domain
- verify the redeploy creates a new version instead of rejecting the app's own alias

## Dependency

- Depends on wasmerio/backend#2894 for the autobuild claim and domain validation fix.

## Validation

- `make fmt-check`
- `make check`

## Known limitation

- The root backend `just run-integration-tests` harness could not complete locally because Edge requires `sudo setcap cap_net_bind_service=+ep edge/target/debug/edge` to bind ports 80/443; it timed out waiting for port 80.
