### PR TITLE
fix: preserve created apps when a template deploy step fails

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ node_modules
 tests/ssh/id_rsa_test
 tests/ssh/id_rsa_test.pub
 fixtures
+repros
 flake.nix
 flake.lock
 Makefile

--- a/repros/WAX-600-edge-wasix-cross-store-panic.sh
+++ b/repros/WAX-600-edge-wasix-cross-store-panic.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Reproduce the Edge wasix 759ca9d cross-Store panic locally.
+# Linear: WAX-600 — https://linear.app/wasmer/issue/WAX-600
+# Run from the wasmer-integration-tests repo root.
+# Knobs:
+#   CPUS=1        edge container CPU cap (lower = more likely to panic)
+#   JEST_CMD=...  test command to run
+#   EDGE_PIN=...  any resolver selector, e.g. a local build to verify a fix:
+#                 EDGE_PIN=path:$HOME/Projects/wasmer/edge/target/release/edge
+#                 (runtime container is debian:bookworm-slim — build against
+#                 glibc <= 2.36 or bump local-platform/edge-runtime/Dockerfile)
+#   BACKEND_PIN=... same, for the backend image archive
+# Details: hivemind knowledge/04-codebases/edge/2026-07-16-wasix-759ca9d-cross-store-panic.md
+set -euo pipefail
+
+CPUS="${CPUS:-2}"
+JEST_CMD="${JEST_CMD:-npx jest ./tests/app/templates.test.ts -t next-react-server-components}"
+BACKEND_PIN="${BACKEND_PIN:-github-release:wasmerio/backend:v2026-07-15_2_9a6c3d4:*image*.tar*}"
+EDGE_PIN="${EDGE_PIN:-github-release:wasmerio/edge:v2026-07-16_1_fcdd9c4_dev1:edge}"
+
+[[ -f docker-compose.local-platform.yaml && -f Makefile ]] ||
+  { echo "error: run from the wasmer-integration-tests repo root" >&2; exit 1; }
+GH_TOKEN="${GH_TOKEN:-$(gh auth token)}" # needs release read on wasmerio/{backend,edge}
+
+# Backups; everything is restored on exit.
+[[ -f local.env ]] && cp local.env local.env.repro-bak
+cp docker-compose.local-platform.yaml docker-compose.local-platform.yaml.repro-bak
+cleanup() {
+  mv -f docker-compose.local-platform.yaml.repro-bak docker-compose.local-platform.yaml
+  if [[ -f local.env.repro-bak ]]; then mv -f local.env.repro-bak local.env; else rm -f local.env; fi
+}
+trap cleanup EXIT
+
+# Pin the versions (local.env overrides ambient env; defaults = failing CI run).
+cat > local.env <<EOF
+export BACKEND_VERSION=$BACKEND_PIN
+export EDGE_VERSION=$EDGE_PIN
+EOF
+
+# Starve the edge container of CPU (the trigger; GH runners have 4 vCPU total)
+# and wipe its caches so instances cold-start like CI.
+sed -i "/^  edge:\$/a\\    cpus: ${CPUS}" docker-compose.local-platform.yaml
+rm -rf .local-platform/cache/edge/compiler_cache .local-platform/cache/edge/webc_cache
+
+rc=0
+GH_TOKEN="$GH_TOKEN" LOCAL_TEST_COMMAND="$JEST_CMD" LOCAL_PLATFORM_AUTO_DOWN=1 \
+  make local-test || rc=$?
+
+LOG=.local-platform/current/logs/compose.follow.log
+echo
+echo "=== verdict (test exit code: $rc) ==="
+if grep -q "object used with the wrong context" "$LOG" 2>/dev/null; then
+  echo "PANIC REPRODUCED:"
+  grep -m1 -B1 -A4 "panicked at" "$LOG"
+else
+  echo "no cross-Store panic in $LOG"
+  echo "retry with a tighter cap: CPUS=1 $0"
+fi

--- a/tests/utils/template-deploy.test.ts
+++ b/tests/utils/template-deploy.test.ts
@@ -1,6 +1,7 @@
-import type { AppTemplate } from "../../src/backend";
+import type { AppInfo, AppTemplate } from "../../src/backend";
+import type { TestEnv } from "../../src/index";
 
-import { shardTemplates } from "./template-deploy";
+import { deployAndValidateTemplate, shardTemplates } from "./template-deploy";
 
 function templates(...slugs: string[]): AppTemplate[] {
   return slugs.map((slug) => ({ name: slug, slug }));
@@ -57,4 +58,105 @@ describe("shardTemplates", () => {
       );
     },
   );
+});
+
+// Cleanup contract for deployAndValidateTemplate: an app that exists
+// server-side when a step fails must flow through the preserve-aware
+// env.deleteApp() queue, never an unconditional `wasmer app delete`.
+// Deleting such an app destroys the evidence needed to investigate
+// deploy-then-unreachable failures (QA-599).
+describe("deployAndValidateTemplate cleanup", () => {
+  const template: AppTemplate = { name: "demo", slug: "demo" };
+
+  interface StubOptions {
+    deployFails?: boolean;
+    appGetFails?: boolean;
+  }
+
+  interface StubCalls {
+    rawDeletes: string[][];
+    queuedDeletes: AppInfo[];
+    recorded: unknown[];
+  }
+
+  function stubEnv(options: StubOptions): { env: TestEnv; calls: StubCalls } {
+    const calls: StubCalls = {
+      rawDeletes: [],
+      queuedDeletes: [],
+      recorded: [],
+    };
+    const env = {
+      namespace: "test-namespace",
+      edgeServer: undefined,
+      runWasmerCommand: async ({ args }: { args: string[] }) => {
+        const command = args.slice(0, 2).join(" ");
+        if (command.startsWith("deploy") && options.deployFails) {
+          throw new Error("App still not reachable after 5 minutes...");
+        }
+        if (command === "app get") {
+          if (options.appGetFails) {
+            throw new Error("Unable to query app");
+          }
+          return {
+            stdout: JSON.stringify({
+              id: "da_stub",
+              name: args[2].split("/")[1],
+              url: "https://stub.wasmer.app",
+              active_version: { id: "dav_stub" },
+            }),
+          };
+        }
+        if (command === "app delete") {
+          calls.rawDeletes.push(args);
+        }
+        return { stdout: "" };
+      },
+      deleteApp: async (app: AppInfo) => {
+        calls.queuedDeletes.push(app);
+      },
+      recordDeployedApp: async (input: unknown) => {
+        calls.recorded.push(input);
+      },
+      fetchApp: async () => ({ status: 200, body: null }),
+    };
+    return { env: env as unknown as TestEnv, calls };
+  }
+
+  test("passing deploy routes cleanup through the preserve-aware queue", async () => {
+    const { env, calls } = stubEnv({});
+
+    await deployAndValidateTemplate(env, template);
+
+    expect(calls.queuedDeletes).toHaveLength(1);
+    expect(calls.rawDeletes).toHaveLength(0);
+  });
+
+  test("unreachable-after-deploy failure preserves the created app", async () => {
+    const { env, calls } = stubEnv({ deployFails: true });
+
+    await expect(deployAndValidateTemplate(env, template)).rejects.toThrow(
+      "not reachable",
+    );
+
+    // The app exists server-side, so it must be recovered, recorded for the
+    // failure report, and queued (where a failed test preserves it) — never
+    // deleted directly.
+    expect(calls.queuedDeletes).toHaveLength(1);
+    expect(calls.queuedDeletes[0].id).toBe("da_stub");
+    expect(calls.recorded).toHaveLength(1);
+    expect(calls.rawDeletes).toHaveLength(0);
+  });
+
+  test("app invisible to `app get` after failure is swept up directly", async () => {
+    const { env, calls } = stubEnv({ deployFails: true, appGetFails: true });
+
+    await expect(deployAndValidateTemplate(env, template)).rejects.toThrow(
+      "not reachable",
+    );
+
+    expect(calls.queuedDeletes).toHaveLength(0);
+    expect(calls.recorded).toHaveLength(0);
+    expect(calls.rawDeletes).toHaveLength(1);
+    expect(calls.rawDeletes[0][2]).toMatch(/^test-namespace\/t-/);
+  });
 });

--- a/tests/utils/template-deploy.ts
+++ b/tests/utils/template-deploy.ts
@@ -175,17 +175,34 @@ export async function deployAndValidateTemplate(
       );
     }
   } catch (err) {
-    if (appInfo) {
-      markCurrentJestTestFailed();
-    }
+    markCurrentJestTestFailed();
     if (options?.formatFailureOutput) {
       throw formatTemplateCommandError(err);
     }
     throw err;
   } finally {
+    if (!appInfo && appCreated) {
+      // A step between `app create` and `app get` threw (e.g. deploy exiting
+      // with "app still not reachable after 5 minutes"), so the app may exist
+      // server-side without a loaded appInfo. Recover it here: deleting it
+      // outright would destroy the one artifact needed to distinguish a
+      // platform routing bug from an app that never existed.
+      appInfo = await loadTemplateAppInfo(
+        env,
+        appName,
+        tempDir,
+        tpl.slug,
+      ).catch(() => null);
+      if (appInfo) {
+        await recordTemplateApp(env, appInfo).catch(() => {});
+      }
+    }
+
     if (appInfo) {
       await env.deleteApp(appInfo);
     } else if (appCreated) {
+      // `app get` cannot see the app, so there is nothing to preserve; sweep
+      // up whatever half-created remnant the backend may still hold.
       await env.runWasmerCommand({
         args: ["app", "delete", `${env.namespace}/${appName}`],
         noAssertSuccess: true,


### PR DESCRIPTION
deployAndValidateTemplate's finally block unconditionally deleted the app whenever a step threw before loadTemplateAppInfo() ran (the appCreated && !appInfo branch). The 'App still not reachable after 5 minutes' failure mode lands exactly there: the app is fully created and deployed, yet gets deleted within seconds of failing - destroying the one artifact needed to investigate QA-599-class failures and making a backend-Edge routing bug indistinguishable from an app that never existed (seen in nightly run 29467910424, templates 4/6, t-68a2cabde3d843d79521).

Now the finally block first recovers the app via 'app get', records it in the deployed-apps registry, and routes it through the preserve-aware env.deleteApp() queue, so a failing test keeps its app exactly like every other suite. The blind name-based delete remains only for apps 'app get' cannot see. Also mark the test failed on every throw, not just when appInfo was already loaded.