### PR TITLE
feat: OpenAPI fixture tests  + NodeJS based impl

### DIFF
--- a/fixtures/node/README.md
+++ b/fixtures/node/README.md
@@ -1,0 +1,27 @@
+# Node fixture
+
+Node implementation of the language-agnostic fixture contract in
+[`../openapi.yaml`](../openapi.yaml). Zero-framework `node:http` server;
+the only dependencies are the pure-JS database drivers (`pg`, `mysql2`)
+needed by `/results`, loaded lazily so every other endpoint runs without
+`node_modules`.
+
+Intended for remote builds: the platform builds from `package.json`
+(`npm start` → `node src/main.js`) — no Wasmer manifest is checked in.
+
+Contract notes specific to this implementation:
+
+- `/sync` vs `/async`: Node has no blocking HTTP I/O, so the two
+  endpoints exercise the two distinct native network stacks instead —
+  the callback-based `node:http(s)` client and the promise-based global
+  `fetch` (undici).
+- Counter atomicity comes from a per-counter promise chain (single
+  process) rather than file locks.
+- `__TEMPLATE__` in `src/main.js` is the per-deployment unique hash
+  placeholder, replaced by the test harness like in the other fixtures.
+
+Run locally:
+
+```bash
+DATA_DIR=/tmp/data PORT=8080 node src/main.js
+```

--- a/fixtures/node/package.json
+++ b/fixtures/node/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "wasmer-integ-tests-node-toolbox",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Node implementation of the fixture contract in fixtures/openapi.yaml",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "start": "node src/main.js"
+  },
+  "dependencies": {
+    "mysql2": "^3.11.0",
+    "pg": "^8.13.0"
+  }
+}

--- a/fixtures/node/src/main.js
+++ b/fixtures/node/src/main.js
@@ -1,0 +1,313 @@
+// Node implementation of the fixture contract (fixtures/openapi.yaml).
+// Zero-framework: node:http only. The pg/mysql2 drivers are loaded lazily
+// inside the /results handler so every other endpoint works without
+// node_modules.
+
+import http from "node:http";
+import https from "node:https";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const HOST = process.env.HOST || "0.0.0.0";
+const PORT = Number(process.env.PORT || 8080);
+const DATA_DIR = process.env.DATA_DIR || "/data";
+
+// Replaced per deployment by the test harness, like the other fixtures.
+const UNIQUE_HASH = "__TEMPLATE__";
+
+const REQUIRED_DB_VARS = [
+  "DB_HOST",
+  "DB_PORT",
+  "DB_USERNAME",
+  "DB_PASSWORD",
+  "DB_NAME",
+];
+
+function json(res, body, status = 200) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function text(res, body, status = 200) {
+  res.writeHead(status, { "Content-Type": "text/plain" });
+  res.end(body);
+}
+
+function timestamp() {
+  const d = new Date();
+  const p = (n) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+  );
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+// --- database-environment -------------------------------------------------
+
+function dbEnvReport() {
+  const present = REQUIRED_DB_VARS.filter((name) => process.env[name] != null);
+  const missing = REQUIRED_DB_VARS.filter((name) => process.env[name] == null);
+  return {
+    present,
+    missing,
+    host: process.env.DB_HOST ?? null,
+    port: process.env.DB_PORT ?? null,
+    name: process.env.DB_NAME ?? null,
+    username: process.env.DB_USERNAME ?? null,
+    hasPassword: process.env.DB_PASSWORD != null,
+    hasDatabaseUrl: process.env.DATABASE_URL != null,
+    hasDbEngine: process.env.DB_ENGINE != null,
+  };
+}
+
+// --- database-connectivity ------------------------------------------------
+
+function dbEngine() {
+  const engine = (process.env.DB_ENGINE || "").toLowerCase();
+  if (engine.includes("postgres") || engine.includes("pg")) {
+    return "postgres";
+  }
+  if (engine.includes("mysql") || engine.includes("maria")) {
+    return "mysql";
+  }
+  const url = process.env.DATABASE_URL || "";
+  if (url.startsWith("postgres")) {
+    return "postgres";
+  }
+  if (url.startsWith("mysql")) {
+    return "mysql";
+  }
+  // Managed apps get neither DB_ENGINE nor DATABASE_URL, only DB_*.
+  // Hostname contract: PostgreSQL endpoints live under psql.<region>,
+  // MySQL under db.<region>/mysql.<region>.
+  const host = process.env.DB_HOST || "";
+  if (host.startsWith("psql.")) {
+    return "postgres";
+  }
+  if (host.startsWith("db.") || host.startsWith("mysql.")) {
+    return "mysql";
+  }
+  return process.env.DB_PORT === "5432" ? "postgres" : "mysql";
+}
+
+async function checkDbConnection() {
+  const missing = REQUIRED_DB_VARS.filter((name) => process.env[name] == null);
+  if (missing.length > 0) {
+    return `Missing required SQL environment variables: ${missing.join(", ")}`;
+  }
+
+  const config = {
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  };
+
+  try {
+    if (dbEngine() === "postgres") {
+      const { default: pg } = await import("pg");
+      const base = { ...config, connectionTimeoutMillis: 10_000 };
+      // TLS first (managed endpoints enforce sslmode=require), plaintext
+      // fallback for TLS-less endpoints like the local platform.
+      const withTls = new pg.Client({
+        ...base,
+        ssl: { rejectUnauthorized: false },
+      });
+      try {
+        await withTls.connect();
+        await withTls.end();
+      } catch (err) {
+        await withTls.end().catch(() => {});
+        if (!/ssl/i.test(err instanceof Error ? err.message : String(err))) {
+          throw err;
+        }
+        const plaintext = new pg.Client(base);
+        await plaintext.connect();
+        await plaintext.end();
+      }
+    } else {
+      const mysql = await import("mysql2/promise");
+      const conn = await mysql.createConnection({
+        ...config,
+        connectTimeout: 10_000,
+      });
+      await conn.end();
+    }
+    return "OK";
+  } catch (err) {
+    return `Connection failed: ${err instanceof Error ? err.message : err}`;
+  }
+}
+
+// --- durable-state --------------------------------------------------------
+
+// The server is a single process, so a per-counter promise chain makes
+// read-modify-write cycles atomic under concurrent requests.
+const counterLocks = new Map();
+
+function withCounterLock(name, fn) {
+  const previous = counterLocks.get(name) || Promise.resolve();
+  const next = previous.then(fn, fn);
+  counterLocks.set(name, next);
+  return next;
+}
+
+function counterValue(name, increment) {
+  return withCounterLock(name, async () => {
+    const file = path.join(DATA_DIR, name);
+    let value = 0;
+    try {
+      value = parseInt(await fs.readFile(file, "utf-8"), 10) || 0;
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        throw err;
+      }
+    }
+    if (increment) {
+      value++;
+      await fs.writeFile(file, String(value));
+    }
+    return value;
+  });
+}
+
+async function handleCounter(req, res, segments) {
+  const name = segments[1] ?? "counter";
+  if (segments.length > 2 || !/^[a-z-]+$/.test(name)) {
+    return text(res, "Not Found", 404);
+  }
+  let increment;
+  if (req.method === "GET") {
+    increment = false;
+  } else if (req.method === "POST") {
+    increment = true;
+  } else {
+    return text(res, "Not Found", 404);
+  }
+  try {
+    const value = await counterValue(name, increment);
+    return text(res, String(value));
+  } catch {
+    return text(res, "Failed to access durable counter storage", 500);
+  }
+}
+
+// --- outbound-http --------------------------------------------------------
+
+// Node has no true blocking HTTP I/O. The two endpoints instead exercise
+// the two distinct native network stacks: /sync uses the callback-based
+// node:http(s) client and /async uses the promise-based global fetch.
+function callbackRequest(method, target, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(target);
+    const client = url.protocol === "https:" ? https : http;
+    const req = client.request(url, { method }, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () =>
+        resolve({
+          body: Buffer.concat(chunks).toString("utf-8"),
+          status_code: res.statusCode,
+        }),
+      );
+      res.on("error", reject);
+    });
+    // A plain timer, not req.setTimeout: the socket inactivity timer does
+    // not cover the connect phase, so unroutable targets would hang past
+    // the deadline.
+    const timer = setTimeout(() => {
+      req.destroy(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    req.on("close", () => clearTimeout(timer));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function fetchRequest(method, target, timeoutMs) {
+  const response = await fetch(target, {
+    method,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return { body: await response.text(), status_code: response.status };
+}
+
+async function handleProxy(req, res, mode) {
+  const start = performance.now();
+  const elapsed = () => Math.round(performance.now() - start);
+  try {
+    const payload = JSON.parse(await readBody(req));
+    const doRequest = mode === "async" ? fetchRequest : callbackRequest;
+    const result = await doRequest(
+      payload.method,
+      payload.target,
+      payload.timeout_ms,
+    );
+    return json(res, { ...result, elapsed_time_ms: elapsed() });
+  } catch (err) {
+    return json(res, {
+      error: String(err instanceof Error ? err.message : err),
+      status_code: 500,
+      elapsed_time_ms: elapsed(),
+    });
+  }
+}
+
+// --- catch-all ------------------------------------------------------------
+
+function handleEcho(req, res, pathname) {
+  const line = `${timestamp()} - ${req.url}`;
+  process.stdout.write(line + "\n");
+  process.stderr.write(line + "\n");
+  return json(res, {
+    echo: pathname.replace(/^\/+|\/+$/g, ""),
+    unique_hash: UNIQUE_HASH,
+  });
+}
+
+// --- router ---------------------------------------------------------------
+
+const server = http.createServer(async (req, res) => {
+  const pathname = new URL(req.url, "http://localhost").pathname;
+  const segments = pathname.split("/").filter(Boolean);
+
+  try {
+    if (pathname === "/" && req.method === "GET") {
+      return json(res, { message: "Hello World" });
+    }
+    if (pathname === "/db-env" && req.method === "GET") {
+      return json(res, dbEnvReport());
+    }
+    if (pathname === "/results" && req.method === "GET") {
+      return text(res, await checkDbConnection());
+    }
+    if (segments[0] === "inc") {
+      return await handleCounter(req, res, segments);
+    }
+    if (pathname === "/async" && req.method === "POST") {
+      return await handleProxy(req, res, "async");
+    }
+    if (pathname === "/sync" && req.method === "POST") {
+      return await handleProxy(req, res, "sync");
+    }
+    if (req.method === "GET") {
+      return handleEcho(req, res, pathname);
+    }
+    return text(res, "Not Found", 404);
+  } catch (err) {
+    return text(res, `Internal error: ${err}`, 500);
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Starting server on http://${HOST}:${PORT}`);
+});

--- a/fixtures/openapi.yaml
+++ b/fixtures/openapi.yaml
@@ -1,0 +1,325 @@
+openapi: 3.1.0
+info:
+  title: Integration Test Fixture Contract
+  version: 1.0.0
+  description: |
+    Language-agnostic functional contract for the integration-test fixture
+    app. Implementations of this spec are generated as stubs for each
+    supported language; every implementation must behave identically so
+    the integration tests can validate the Wasmer virtualization backend
+    across all deployment targets — the local platform, Edge, and Edge in
+    the cloud — independently of the language the fixture is written in.
+
+    Capabilities covered: instance liveness, environment introspection for
+    managed databases, database connectivity, durable state via persistent
+    counters, outbound HTTP (blocking and non-blocking), and a catch-all
+    path echo with request logging.
+servers:
+  - url: "{appUrl}"
+    description: >-
+      Per-deployment base URL assigned when the fixture app is deployed to
+      the target under test (local platform, Edge, or cloud Edge).
+    variables:
+      appUrl:
+        default: http://localhost
+security: []
+tags:
+  - name: liveness
+    description: Prove the instance is up and serving requests.
+  - name: database-environment
+    description: >-
+      Introspect the managed-database environment variables injected into
+      the app, without opening a database connection.
+  - name: database-connectivity
+    description: >-
+      Open a real connection to the managed database using the injected
+      credentials.
+  - name: durable-state
+    description: >-
+      Persistent counters backed by the app's durable volume, proving
+      state survives across requests, instances, and restarts.
+  - name: outbound-http
+    description: >-
+      Perform outbound HTTP requests from inside the instance, in both
+      blocking and non-blocking mode, with a caller-controlled timeout.
+  - name: catch-all
+    description: >-
+      Any path not matched by another endpoint: echo the request path and
+      emit a log line, for routing and log-collection validation.
+paths:
+  /:
+    get:
+      tags: [liveness]
+      operationId: liveness
+      summary: Liveness greeting
+      description: Confirms the instance is running and can serve a response.
+      responses:
+        "200":
+          description: Fixed greeting payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    const: Hello World
+                required: [message]
+  /db-env:
+    get:
+      tags: [database-environment]
+      operationId: getDbEnvReport
+      summary: Report which managed-database env vars are injected
+      description: >-
+        Engine-agnostic: must never open a database connection, so it works
+        for any managed database engine. Non-secret values are echoed back;
+        the password is only reported as a presence boolean and must never
+        be included in the response.
+      responses:
+        "200":
+          description: Database environment report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DbEnvReport"
+  /results:
+    get:
+      tags: [database-connectivity]
+      operationId: checkDbConnection
+      summary: Check database connectivity using the injected credentials
+      description: >-
+        Opens a connection to the managed database using the injected
+        `DB_*` environment variables and reports the outcome. Returns the
+        plain-text body `OK` on success. On failure the body names the
+        missing environment variables or describes the connection error.
+      responses:
+        "200":
+          description: Connectivity result (`OK` or an error description)
+          content:
+            text/plain:
+              schema:
+                type: string
+                examples: ["OK"]
+  /inc:
+    get:
+      tags: [durable-state]
+      operationId: readDefaultCounter
+      summary: Read the default counter without incrementing
+      responses:
+        "200":
+          $ref: "#/components/responses/CounterValue"
+        "500":
+          $ref: "#/components/responses/CounterFailure"
+    post:
+      tags: [durable-state]
+      operationId: incrementDefaultCounter
+      summary: Increment the default counter and return the new value
+      description: >-
+        Increments must be atomic under concurrent requests (e.g. guarded
+        by a file lock or equivalent), so parallel increments never lose
+        updates.
+      responses:
+        "200":
+          $ref: "#/components/responses/CounterValue"
+        "500":
+          $ref: "#/components/responses/CounterFailure"
+  /inc/{name}:
+    parameters:
+      - $ref: "#/components/parameters/CounterName"
+    get:
+      tags: [durable-state]
+      operationId: readNamedCounter
+      summary: Read a named counter without incrementing
+      responses:
+        "200":
+          $ref: "#/components/responses/CounterValue"
+        "404":
+          description: Counter name does not match `^[a-z-]+$`
+        "500":
+          $ref: "#/components/responses/CounterFailure"
+    post:
+      tags: [durable-state]
+      operationId: incrementNamedCounter
+      summary: Increment a named counter and return the new value
+      description: >-
+        Same atomicity requirement as the default counter. A counter that
+        has never been written reads as `0`.
+      responses:
+        "200":
+          $ref: "#/components/responses/CounterValue"
+        "404":
+          description: Counter name does not match `^[a-z-]+$`
+        "500":
+          $ref: "#/components/responses/CounterFailure"
+  /async:
+    post:
+      tags: [outbound-http]
+      operationId: proxyRequestNonBlocking
+      summary: Perform an outbound HTTP request using non-blocking I/O
+      description: >-
+        Issues the requested outbound HTTP call using the implementation
+        language's non-blocking / asynchronous I/O mechanism.
+      requestBody:
+        $ref: "#/components/requestBodies/ProxyRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProxyResult"
+  /sync:
+    post:
+      tags: [outbound-http]
+      operationId: proxyRequestBlocking
+      summary: Perform an outbound HTTP request using blocking I/O
+      description: >-
+        Issues the requested outbound HTTP call using the implementation
+        language's blocking / synchronous I/O mechanism.
+      requestBody:
+        $ref: "#/components/requestBodies/ProxyRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProxyResult"
+  /{path}:
+    get:
+      tags: [catch-all]
+      operationId: echoPath
+      summary: Echo the request path and log the request
+      description: >-
+        Handles every path not matched by another endpoint. The response
+        echoes the request path (leading and trailing slashes stripped)
+        together with the instance's unique deployment hash, which tests
+        use to distinguish deployments and bust caches. In addition, each
+        request emits a `YYYY-mm-dd HH:ii:ss - <path>` line to both stdout
+        and stderr so log-collection tests can assert on it.
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Any request path not matched by another endpoint
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Path echo
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  echo:
+                    type: string
+                    description: Request path with surrounding slashes stripped
+                  unique_hash:
+                    type: string
+                    description: Per-deployment unique value injected at deploy time
+                required: [echo, unique_hash]
+components:
+  parameters:
+    CounterName:
+      name: name
+      in: path
+      required: true
+      description: Counter name; must match `^[a-z-]+$` (default counter is `counter`)
+      schema:
+        type: string
+        pattern: "^[a-z-]+$"
+  requestBodies:
+    ProxyRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              method:
+                type: string
+                description: HTTP method for the outbound request
+              target:
+                type: string
+                format: uri
+                description: URL to request
+              timeout_ms:
+                type: number
+                description: Request timeout in milliseconds
+            required: [method, target, timeout_ms]
+  responses:
+    CounterValue:
+      description: Current counter value
+      content:
+        text/plain:
+          schema:
+            type: integer
+    CounterFailure:
+      description: Failed to access the durable counter storage
+    ProxyResult:
+      description: >-
+        Outcome of the outbound request. Errors (including timeouts) are
+        reported in-band with HTTP 200 and an `error` field, so tests can
+        always read the elapsed time.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - type: object
+                properties:
+                  body:
+                    type: string
+                    description: Response body of the outbound request
+                  status_code:
+                    type: integer
+                    description: Status code of the outbound request
+                  elapsed_time_ms:
+                    type: integer
+                    description: Wall-clock duration of the outbound request
+                required: [body, status_code, elapsed_time_ms]
+              - type: object
+                properties:
+                  error:
+                    type: string
+                    description: Human-readable failure reason
+                  status_code:
+                    type: integer
+                    const: 500
+                  elapsed_time_ms:
+                    type: integer
+                    description: Wall-clock duration until the failure
+                required: [error, status_code, elapsed_time_ms]
+  schemas:
+    DbEnvReport:
+      type: object
+      properties:
+        present:
+          type: array
+          items:
+            type: string
+          description: Required `DB_*` vars that are set
+        missing:
+          type: array
+          items:
+            type: string
+          description: Required `DB_*` vars that are absent
+        host:
+          type: [string, "null"]
+        port:
+          type: [string, "null"]
+        name:
+          type: [string, "null"]
+        username:
+          type: [string, "null"]
+        hasPassword:
+          type: boolean
+          description: Whether `DB_PASSWORD` is set (value never echoed)
+        hasDatabaseUrl:
+          type: boolean
+          description: Whether `DATABASE_URL` is set
+        hasDbEngine:
+          type: boolean
+          description: Whether `DB_ENGINE` is set
+      required:
+        - present
+        - missing
+        - host
+        - port
+        - name
+        - username
+        - hasPassword
+        - hasDatabaseUrl
+        - hasDbEngine

--- a/tests/app/node-fixture-contract.test.ts
+++ b/tests/app/node-fixture-contract.test.ts
@@ -1,0 +1,195 @@
+import * as fs from "node:fs";
+import * as pathModule from "node:path";
+
+import { AppInfo, TestEnv, randomAppName } from "../../src/index";
+import { createTempDir } from "../../src/fs";
+import { projectRoot } from "../utils/path";
+import {
+  NO_PSQL_CONFIG_RE,
+  postgresRegionCandidates,
+} from "../utils/app-databases";
+import {
+  assertDatabaseConnectivity,
+  assertDatabaseEnvReport,
+  assertFixtureContract,
+  randomContractSuffix,
+  targetFromUrl,
+} from "../utils/fixture-contract";
+
+// Validates the language-agnostic fixture contract (fixtures/openapi.yaml)
+// against its Node implementation (fixtures/node), deployed through the
+// remote-build (autobuild) pipeline from nothing but package.json + app.yaml.
+//
+// The contract assertions themselves live in tests/utils/fixture-contract.ts
+// and are implementation-agnostic — this file only owns deploying the Node
+// fixture in its three configurations (volume-only, MySQL, PostgreSQL).
+// Database connectivity is asserted *from inside the app* (/results), which
+// the psql/sql suites deliberately do not cover: they round-trip from the
+// test runner only.
+
+const REMOTE_BUILD_TIMEOUT = 15 * 60 * 1000;
+
+const NODE_FIXTURE_DIR = pathModule.join(projectRoot, "fixtures", "node");
+
+// Copy the fixture sources into a temp dir and write an app.yaml with the
+// given extra config (volumes, database capability, region pinning). The
+// fixture itself stays free of Wasmer manifests; the deploy relies on the
+// remote-build node preset detecting package.json.
+async function prepareDeployDir(
+  env: TestEnv,
+  appName: string,
+  appYamlExtra: string,
+): Promise<string> {
+  const dir = await createTempDir();
+  for (const entry of ["package.json", "src"]) {
+    await fs.promises.cp(
+      pathModule.join(NODE_FIXTURE_DIR, entry),
+      pathModule.join(dir, entry),
+      { recursive: true },
+    );
+  }
+  const appYaml = `kind: wasmer.io/App.v0
+name: ${appName}
+owner: ${env.namespace}
+package: .
+${appYamlExtra}`;
+  await fs.promises.writeFile(pathModule.join(dir, "app.yaml"), appYaml);
+  return dir;
+}
+
+async function deployNodeFixture(
+  env: TestEnv,
+  appYamlExtra: string,
+): Promise<AppInfo> {
+  const dir = await prepareDeployDir(env, randomAppName(), appYamlExtra);
+  return env.deployAppDir(dir, { extraCliArgs: ["--build-remote"] });
+}
+
+test.concurrent(
+  "node-fixture-contract-endpoints",
+  async () => {
+    const env = TestEnv.fromEnv();
+
+    console.log("== Deploying the Node fixture via remote build ==");
+    const app = await deployNodeFixture(
+      env,
+      `volumes:
+  - name: data
+    mount: /data
+`,
+    );
+
+    try {
+      // The contract only ever sees the deployed app's URL; the Node
+      // implementation behind it is invisible to the assertions.
+      const target = targetFromUrl(env, app.url, {
+        appName: app.version.name,
+      });
+      await assertFixtureContract(target, {
+        expectDatabase: false,
+        uniqueSuffix: randomContractSuffix(),
+        checkLogs: true,
+      });
+    } finally {
+      await env.deleteApp(app);
+    }
+  },
+  REMOTE_BUILD_TIMEOUT,
+);
+
+test.concurrent(
+  "node-fixture-mysql-connectivity",
+  async () => {
+    const env = TestEnv.fromEnv();
+
+    console.log("== Deploying the Node fixture with a MySQL database ==");
+    // Omitted engine provisions MySQL (compatibility commitment covered by
+    // psql.test.ts). Pinned to a database-capable region: unpinned apps can
+    // land on unhealthy Edge capacity and never become reachable.
+    const candidates = await postgresRegionCandidates(env);
+    const app = await deployNodeFixture(
+      env,
+      `capabilities:
+  database: {}
+${candidates.length > 0 ? `locality:\n  regions:\n    - ${candidates[0]}\n` : ""}`,
+    );
+
+    try {
+      const target = targetFromUrl(env, app.url);
+      await assertDatabaseEnvReport(target, { expectDatabase: true });
+      console.log("== The app must reach its database from the inside ==");
+      await assertDatabaseConnectivity(target, { expectDatabase: true });
+    } finally {
+      await env.deleteApp(app);
+    }
+  },
+  REMOTE_BUILD_TIMEOUT,
+);
+
+test.concurrent(
+  "node-fixture-postgres-connectivity",
+  async () => {
+    const env = TestEnv.fromEnv();
+
+    const candidates = await postgresRegionCandidates(env);
+    if (candidates.length === 0) {
+      console.warn(
+        "No active database-capable regions exposed by this environment; skipping PostgreSQL connectivity coverage.",
+      );
+      return;
+    }
+
+    console.log("== Deploying the Node fixture with a PostgreSQL database ==");
+    // Region fallback mirrors deployPostgresAppWithRegionFallback, which only
+    // supports AppDefinition specs; this deploy goes through a directory.
+    let app: AppInfo | undefined;
+    for (const region of candidates) {
+      const appName = randomAppName();
+      const dir = await prepareDeployDir(
+        env,
+        appName,
+        `capabilities:
+  database:
+    engine: postgres
+locality:
+  regions:
+    - ${region}
+`,
+      );
+      try {
+        app = await env.deployAppDir(dir, {
+          extraCliArgs: ["--build-remote"],
+        });
+        break;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!NO_PSQL_CONFIG_RE.test(message)) {
+          throw error;
+        }
+        console.warn(
+          `Region ${region} has no PostgreSQL config; trying the next candidate.`,
+        );
+        await env.runWasmerCommand({
+          args: ["app", "delete", `${env.namespace}/${appName}`],
+          noAssertSuccess: true,
+          quiet: true,
+        });
+      }
+    }
+    if (!app) {
+      throw new Error(
+        `No candidate region has a PostgreSQL database config (tried: ${candidates.join(", ")})`,
+      );
+    }
+
+    try {
+      const target = targetFromUrl(env, app.url);
+      await assertDatabaseEnvReport(target, { expectDatabase: true });
+      console.log("== The app must reach its database from the inside ==");
+      await assertDatabaseConnectivity(target, { expectDatabase: true });
+    } finally {
+      await env.deleteApp(app);
+    }
+  },
+  REMOTE_BUILD_TIMEOUT,
+);

--- a/tests/utils/fixture-contract.ts
+++ b/tests/utils/fixture-contract.ts
@@ -1,0 +1,356 @@
+import { AppFetchOptions, TestEnv } from "../../src/env";
+import { HEADER_PURGE_INSTANCES, pollUntil, sleep } from "../../src/index";
+import { getAllLogs } from "../../src/log";
+
+// Shared, implementation-agnostic assertions for the fixture contract
+// (fixtures/openapi.yaml). The real contract is the OpenAPI spec, not any
+// single fixture: each language's test file deploys its own fixture app and
+// passes the resulting URL in here — the assertions only ever see the URL,
+// so the implementation behind it is fully abstracted away.
+//
+// Each assert* function covers one contract capability and reads as a
+// linear arrange-act-assert scenario. Fixtures implementing only a subset
+// of the spec (e.g. the Python toolbox) call the individual functions;
+// full implementations run assertFixtureContract.
+//
+// All assertions are idempotent per app: counters assert relative
+// increments and named counters use a caller-supplied unique name, so the
+// same contract can be re-validated against a long-lived deployment.
+
+export interface FixtureContractTarget {
+  env: TestEnv;
+  /** Fetch a contract path (starting with /) from the target app. */
+  fetch: (path: string, options?: AppFetchOptions) => Promise<Response>;
+  /** App name; enables assertions that inspect platform logs. */
+  appName?: string;
+}
+
+/**
+ * Build a contract target from an app URL (e.g. `https://<domain>`).
+ * Requests are routed via env.fetchAppUrlThroughEdge so they work on the
+ * local platform too. Pass `appName` to enable log-based assertions.
+ */
+export function targetFromUrl(
+  env: TestEnv,
+  baseUrl: string,
+  options?: { appName?: string },
+): FixtureContractTarget {
+  const base = baseUrl.replace(/\/+$/, "");
+  return {
+    env,
+    fetch: (path, fetchOptions) =>
+      env.fetchAppUrlThroughEdge(`${base}${path}`, fetchOptions),
+    appName: options?.appName,
+  };
+}
+
+/**
+ * Unique per-run suffix for counter names and echo paths. Lowercase letters
+ * only: counter names must match `^[a-z-]+$`.
+ */
+export function randomContractSuffix(length = 12): string {
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += String.fromCharCode(97 + Math.floor(Math.random() * 26));
+  }
+  return out;
+}
+
+export const REQUIRED_DB_VARS = [
+  "DB_HOST",
+  "DB_NAME",
+  "DB_PASSWORD",
+  "DB_PORT",
+  "DB_USERNAME",
+];
+
+export interface DbEnvReport {
+  present: string[];
+  missing: string[];
+  host: string | null;
+  port: string | null;
+  name: string | null;
+  username: string | null;
+  hasPassword: boolean;
+  hasDatabaseUrl: boolean;
+  hasDbEngine: boolean;
+}
+
+interface ProxyResult {
+  body?: string;
+  error?: string;
+  status_code: number;
+  elapsed_time_ms: number;
+}
+
+async function getJson<T>(
+  target: FixtureContractTarget,
+  path: string,
+): Promise<T> {
+  const res = await target.fetch(path);
+  expect(res.status).toBe(200);
+  return (await res.json()) as T;
+}
+
+async function getTextOk(
+  target: FixtureContractTarget,
+  path: string,
+): Promise<string> {
+  const res = await target.fetch(path);
+  expect(res.status).toBe(200);
+  return (await res.text()).trim();
+}
+
+/** GET / answers with the fixed greeting payload. */
+export async function assertLiveness(
+  target: FixtureContractTarget,
+): Promise<void> {
+  expect(await getJson(target, "/")).toEqual({ message: "Hello World" });
+}
+
+/**
+ * GET /db-env reports exactly the injected DB_* environment: all five when
+ * the app has a database capability, none otherwise. The password is only
+ * ever reported as a boolean.
+ */
+export async function assertDatabaseEnvReport(
+  target: FixtureContractTarget,
+  options: { expectDatabase: boolean },
+): Promise<DbEnvReport> {
+  const report = await getJson<DbEnvReport>(target, "/db-env");
+  if (options.expectDatabase) {
+    expect(report.missing).toEqual([]);
+    expect(report.present.sort()).toEqual(REQUIRED_DB_VARS);
+    expect(report.hasPassword).toBe(true);
+    expect(report.host).toBeTruthy();
+  } else {
+    expect(report.present).toEqual([]);
+    expect(report.missing.sort()).toEqual(REQUIRED_DB_VARS);
+    expect(report.hasPassword).toBe(false);
+    expect(report.host).toBeNull();
+  }
+  return report;
+}
+
+/**
+ * GET /results opens a real database connection from inside the app using
+ * the injected credentials — `OK` with a database, the missing env vars
+ * named without one.
+ */
+export async function assertDatabaseConnectivity(
+  target: FixtureContractTarget,
+  options: { expectDatabase: boolean },
+): Promise<void> {
+  const body = await getTextOk(target, "/results");
+  if (options.expectDatabase) {
+    expect(body).toBe("OK");
+  } else {
+    expect(body).toContain("Missing required SQL environment variables");
+    for (const name of REQUIRED_DB_VARS) {
+      expect(body).toContain(name);
+    }
+  }
+}
+
+async function counterValue(
+  target: FixtureContractTarget,
+  path: string,
+  options?: AppFetchOptions,
+): Promise<number> {
+  const res = await target.fetch(path, options);
+  expect(res.status).toBe(200);
+  const body = (await res.text()).trim();
+  expect(body).toMatch(/^\d+$/);
+  return parseInt(body, 10);
+}
+
+/**
+ * /inc counters increment atomically, are independent per name, reject
+ * invalid names, and survive an instance restart (the volume-backed
+ * durability claim). Assertions are relative to the starting value so the
+ * contract can be re-run against the same app.
+ */
+export async function assertDurableCounters(
+  target: FixtureContractTarget,
+  options: { uniqueCounterName: string },
+): Promise<void> {
+  const initial = await counterValue(target, "/inc");
+  expect(await counterValue(target, "/inc", { method: "POST" })).toBe(
+    initial + 1,
+  );
+  expect(await counterValue(target, "/inc", { method: "POST" })).toBe(
+    initial + 2,
+  );
+  expect(await counterValue(target, "/inc")).toBe(initial + 2);
+
+  // A never-written counter reads as 0, and increments independently of
+  // the default counter.
+  const named = `/inc/${options.uniqueCounterName}`;
+  expect(await counterValue(target, named)).toBe(0);
+  expect(await counterValue(target, named, { method: "POST" })).toBe(1);
+  expect(await counterValue(target, named)).toBe(1);
+  expect(await counterValue(target, "/inc")).toBe(initial + 2);
+
+  const badName = await target.fetch("/inc/NOT-VALID", {
+    acceptStatus: (status) => status === 404,
+  });
+  expect(badName.status).toBe(404);
+  await badName.body?.cancel();
+
+  // Restart durability: purge the running instance and read again.
+  expect(
+    await counterValue(target, "/inc", {
+      headers: { [HEADER_PURGE_INSTANCES]: "1" },
+    }),
+  ).toBe(initial + 2);
+  expect(await counterValue(target, named)).toBe(1);
+}
+
+// Proxy responses are JSON by contract, but an Edge instance warming up can
+// briefly answer with a non-JSON error page; retry parsing on a deadline.
+async function postProxy(
+  target: FixtureContractTarget,
+  path: string,
+  payload: unknown,
+  timeoutMs = 60_000,
+): Promise<ProxyResult> {
+  const start = Date.now();
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    const res = await target.fetch(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.text();
+    try {
+      return JSON.parse(body) as ProxyResult;
+    } catch (err) {
+      lastError = err;
+      await sleep(1000);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * POST /sync and /async perform outbound requests from inside the instance
+ * through the implementation's blocking and non-blocking I/O paths, and
+ * report failures in-band (HTTP 200 with an error object).
+ */
+export async function assertOutboundHttp(
+  target: FixtureContractTarget,
+): Promise<void> {
+  for (const path of ["/sync", "/async"]) {
+    const ok = await postProxy(target, path, {
+      method: "GET",
+      target: "http://example.com",
+      timeout_ms: 10_000,
+    });
+    expect(ok.error).toBeUndefined();
+    expect(ok.status_code).toBe(200);
+    expect(ok.body).toContain("Example Domain");
+    expect(ok.elapsed_time_ms).toBeLessThanOrEqual(10_000);
+  }
+
+  for (const path of ["/sync", "/async"]) {
+    // Unroutable TEST-NET-1 address: the request must fail, and the failure
+    // must come back in-band.
+    const failed = await postProxy(target, path, {
+      method: "GET",
+      target: "http://192.0.2.1/",
+      timeout_ms: 2_000,
+    });
+    expect(failed.error).toBeTruthy();
+    expect(failed.body).toBeUndefined();
+    expect(failed.status_code).toBe(500);
+    expect(typeof failed.elapsed_time_ms).toBe("number");
+  }
+}
+
+/**
+ * Unmatched paths echo the request path with the deployment's unique hash.
+ * Returns the echoed path for the optional log assertion.
+ */
+export async function assertCatchAllEcho(
+  target: FixtureContractTarget,
+  options: { uniquePathSegment: string },
+): Promise<string> {
+  const echoPath = `spec-echo/${options.uniquePathSegment}`;
+  const echo = await getJson<{ echo: string; unique_hash: string }>(
+    target,
+    `/${echoPath}?ignored=1`,
+  );
+  expect(echo.echo).toBe(echoPath);
+  expect(typeof echo.unique_hash).toBe("string");
+  expect(echo.unique_hash.length).toBeGreaterThan(0);
+  return echoPath;
+}
+
+/**
+ * Each catch-all request emits a timestamped log line that reaches the
+ * platform's log pipeline. Requires a target with a known app name.
+ */
+export async function assertCatchAllLogging(
+  target: FixtureContractTarget,
+  echoPath: string,
+): Promise<void> {
+  const appName = target.appName;
+  if (!appName) {
+    throw new Error(
+      "assertCatchAllLogging needs a target with an app name (targetFromAppInfo)",
+    );
+  }
+  const logLine = new RegExp(
+    `\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} - /${echoPath}`,
+  );
+  await pollUntil(
+    async () => logLine.test(await getAllLogs(target.env, appName)),
+    {
+      timeoutMs: 180_000,
+      intervalMs: 10_000,
+      description: "catch-all log line visible in app logs",
+    },
+  );
+}
+
+/**
+ * Validate the full contract against a target, walking every capability in
+ * fixtures/openapi.yaml. `uniqueSuffix` must be fresh per run (e.g. a
+ * random app name) so counter and echo assertions stay idempotent.
+ */
+export async function assertFixtureContract(
+  target: FixtureContractTarget,
+  options: {
+    expectDatabase: boolean;
+    uniqueSuffix: string;
+    /** Assert the catch-all log line via platform logs (needs appName). */
+    checkLogs?: boolean;
+  },
+): Promise<void> {
+  console.log("== contract: liveness ==");
+  await assertLiveness(target);
+
+  console.log("== contract: database-environment ==");
+  await assertDatabaseEnvReport(target, options);
+
+  console.log("== contract: database-connectivity ==");
+  await assertDatabaseConnectivity(target, options);
+
+  console.log("== contract: durable-state ==");
+  await assertDurableCounters(target, {
+    uniqueCounterName: options.uniqueSuffix,
+  });
+
+  console.log("== contract: outbound-http ==");
+  await assertOutboundHttp(target);
+
+  console.log("== contract: catch-all ==");
+  const echoPath = await assertCatchAllEcho(target, {
+    uniquePathSegment: options.uniqueSuffix,
+  });
+  if (options.checkLogs) {
+    console.log("== contract: catch-all logging ==");
+    await assertCatchAllLogging(target, echoPath);
+  }
+}


### PR DESCRIPTION
In order to ensure that we are compatible with different languages, we should have a standardized contract
of expectations. This is modeled in the openAPI spec containing endpoints which in turn describe some 
functionality that we've added to fixtures. 

The second step is to add an app which in turn implements this functionality, in some language. The first one
is nodejs, as that's what we recently added.

This way we can very easily ensure that we have feature parity in different languages by simply ensuring that
they fullfill the openapi fixture contract. Also easy to extend once we get additional requirements. The fixtures
can later on also be used in loadtests to compare performance etc.

Closes: QA-667